### PR TITLE
Add missing srcs/deps

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -10,13 +10,16 @@ compile_pip_requirements(
 py_binary(
     name = "genparser",
     srcs = ["genparser.py"],
-    deps = ["@pypi//astor"],
     visibility = ["//visibility:public"],
+    deps = [
+        ":fltk",
+        "@pypi//astor",
+    ],
 )
 
 py_library(
     name = "fltk",
-    srcs = glob(["fltk/**/*.py"]),
+    srcs = glob(["**/*.py"]),
     data = ["fltk/py.typed"],
     visibility = ["//visibility:public"],
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -5,10 +5,9 @@ module(
 bazel_dep(name = "rules_python", version = "0.26.0")
 
 python = use_extension("@rules_python//python/extensions:python.bzl", "python")
-
 python.toolchain(
-    python_version = "3.10",
     is_default = True,
+    python_version = "3.10",
 )
 
 pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")


### PR DESCRIPTION
Testing with Aspect's `rules_py` exposed a missing dependency in `//:genparser`, as well as missing `srcs` in `//:fltk`. This adds the missing `dep` and `srcs`.